### PR TITLE
Fix typo

### DIFF
--- a/library/lineinfile
+++ b/library/lineinfile
@@ -181,7 +181,7 @@ def main():
             regexp=dict(required=True),
             line=dict(aliases=['value']),
             insertafter=dict(default='EOF'),
-            create=dict(default=false, choices=BOOLEANS),
+            create=dict(default=False, choices=BOOLEANS),
             backup=dict(default=False, choices=BOOLEANS),
         ),
     )


### PR DESCRIPTION
Testing your patch I got this error:

 TASK: [lineinfile dest=/home/serge/TEST regexp="test" line="test"  create=yes] ********************\* 
 <antares.ginsys.net> ESTABLISH CONNECTION FOR USER: serge on PORT 22 TO  antares.ginsys.net
 <antares.ginsys.net> EXEC /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-1351622315.05-48913684414253 && chmod a+rx $HOME/.ansible/tmp/ansible-1351622315.05-48913684414253 && echo $HOME/.ansible/tmp/ansible-1351622315.05-48913684414253'
 <antares.ginsys.net> REMOTE_MODULE lineinfile dest=/home/serge/TEST regexp="test" line="test"  create=yes
 <antares.ginsys.net> PUT /tmp/tmpbvzOpB TO /home/serge/.ansible/tmp/ansible-1351622315.05-48913684414253/lineinfile
 <antares.ginsys.net> EXEC /bin/sh -c '/usr/bin/python /home/serge/.ansible/tmp/ansible-1351622315.05-48913684414253/lineinfile; rm -rf /home/serge/.ansible/tmp/ansible-1351622315.05-48913684414253/ >/dev/null 2>&1'
fatal: [antares.ginsys.net] => failed to parse: Traceback (most recent call last):

 File "/home/serge/.ansible/tmp/ansible-1351622315.05-48913684414253/lineinfile", line 797, in <module>

 main()

 File "/home/serge/.ansible/tmp/ansible-1351622315.05-48913684414253/lineinfile", line 184, in main
 create=dict(default=false, choices=BOOLEANS),
 NameError: global name 'false' is not defined

 FATAL: all hosts have already failed -- aborting
